### PR TITLE
Feat/api design

### DIFF
--- a/apps/backend/app/api/api_router.py
+++ b/apps/backend/app/api/api_router.py
@@ -1,0 +1,10 @@
+# apps/backend/app/api/api_router.py
+from fastapi import APIRouter
+from app.api.endpoints import companies, reports, news
+
+api_router = APIRouter()
+
+# 여기서 '/api' 프리픽스를 붙일 수도 있지만, 사용자 요청대로 직관적으로 갑니다.
+api_router.include_router(companies.router, tags=["Companies"])
+api_router.include_router(reports.router, tags=["Report"])
+api_router.include_router(news.router, tags=["News"])

--- a/apps/backend/app/api/api_router.py
+++ b/apps/backend/app/api/api_router.py
@@ -1,10 +1,11 @@
-# apps/backend/app/api/api_router.py
 from fastapi import APIRouter
 from app.api.endpoints import companies, reports, news
 
+# 전체 API 라우터 생성
 api_router = APIRouter()
 
-# 여기서 '/api' 프리픽스를 붙일 수도 있지만, 사용자 요청대로 직관적으로 갑니다.
+# 각 파일(Controller)에서 만든 라우터를 여기에 등록합니다.
+# tags: Swagger UI(/docs)에서 API를 그룹핑해서 보여줄 이름입니다.
 api_router.include_router(companies.router, tags=["Companies"])
 api_router.include_router(reports.router, tags=["Report"])
 api_router.include_router(news.router, tags=["News"])

--- a/apps/backend/app/api/deps.py
+++ b/apps/backend/app/api/deps.py
@@ -2,6 +2,7 @@ import os
 import ast
 from typing import List, Generator, Any
 from google.cloud import bigquery
+from dotenv import load_dotenv
 
 # .env 파일 로드 (파일이 없으면 시스템 환경변수 사용)
 load_dotenv()

--- a/apps/backend/app/api/deps.py
+++ b/apps/backend/app/api/deps.py
@@ -1,29 +1,59 @@
+import os
 import ast
-from typing import List
-from apps.dataflow.common.db_sa import get_db_session
+from typing import List, Generator, Any
+from google.cloud import bigquery
 
-# [DB 세션 의존성]
-# Controller에서 'Depends(get_db)'로 호출하면,
-# 자동으로 DB 커넥션을 하나 꺼내주고, 요청이 끝나면 닫아줍니다.
-get_db = get_db_session
+# .env 파일 로드 (파일이 없으면 시스템 환경변수 사용)
+load_dotenv()
 
-def parse_keywords(keyword_str: str) -> List[str]:
+# =========================================================
+# [환경변수 로드 및 검증]
+# 코드가 실행될 때 설정값이 없으면 에러를 띄워서 실수를 방지합니다.
+# =========================================================
+PROJECT_ID = os.getenv("GCP_PROJECT_ID")
+DATASET_ID = os.getenv("BIGQUERY_DATASET_ID")
+RAW_TABLE_NAME = os.getenv("TABLE_NEWS_RAW")
+LLM_TABLE_NAME = os.getenv("TABLE_NEWS_LLM")
+
+# 필수 설정값 체크 (배포 시 실수 방지용)
+if not all([PROJECT_ID, DATASET_ID, RAW_TABLE_NAME, LLM_TABLE_NAME]):
+    raise ValueError("❌ 필수 환경변수(.env)가 설정되지 않았습니다. GCP_PROJECT_ID 등을 확인하세요.")
+
+def get_bq_client() -> Generator[bigquery.Client, None, None]:
     """
-    [유틸리티 함수]
-    DB에 저장된 키워드 문자열은 "[('키워드', 10), ...]" 형태의 텍스트입니다.
-    이것을 파이썬 리스트 ['키워드', ...] 형태로 예쁘게 변환해줍니다.
-    
-    Args:
-        keyword_str (str): DB에서 꺼낸 raw string
-        
-    Returns:
-        List[str]: 파싱된 키워드 리스트 (실패 시 빈 리스트 반환)
+    [DI] 빅쿼리 클라이언트를 생성.
+        1. 시작 : client 생성 + yield( API 함수에 전달)
+        2. 처리 : API 함수가 이 client를 사용해 DB 조회
+        3. 종료 : finally 실행 -> client.close()
     """
+    client = bigquery.Client(project=PROJECT_ID)
     try:
-        if not keyword_str: return []
-        # 문자열로 된 리스트 표현식을 실제 파이썬 객체로 안전하게 변환
-        data = ast.literal_eval(keyword_str) 
-        # 튜플 (키워드, 빈도수) 중 키워드만 추출
-        return [k for k, v in data] if isinstance(data, list) else []
+        yield client
+    finally:
+        client.close()
+
+def parse_keywords(keyword_data: Any) -> List[str]:
+    """
+    [유틸리티]
+    빅 쿼리에 저장된 키워드 데이터가 다양한 형태(문자열, 리스트, 구조체 등)로 저장될 가능성이 있어서
+    안전하게 파이썬 리스트['키워드1', '키워드2']로 반환
+    """
+    if not keyword_data:
+        return []
+    
+    # Case 1: 이미 리스트(ARRAY) 형태인 경우
+    if isinstance(keyword_data, list):
+        # 내부가 딕셔너리(Struct)인 경우 처리
+        if keyword_data and isinstance(keyword_data[0], dict):
+             return [item.get('keyword', item) for item in keyword_data]
+        return keyword_data
+
+    # Case 2: 문자열("[('키워드', 10), ...]") 형태인 경우
+    try:
+        data = ast.literal_eval(str(keyword_data))
+        # [('키워드', 10), ...] 튜플 형태라면 키워드만 추출
+        if isinstance(data, list) and data and isinstance(data[0], tuple):
+            return [k for k, v in data]
+        return data if isinstance(data, list) else []
     except:
         return []

--- a/apps/backend/app/api/deps.py
+++ b/apps/backend/app/api/deps.py
@@ -1,16 +1,29 @@
-# DB 세션을 가져오는 공통 함수.
 import ast
 from typing import List
 from apps.dataflow.common.db_sa import get_db_session
 
-# Controller에서 'Depends(get_db)'로 사용
+# [DB 세션 의존성]
+# Controller에서 'Depends(get_db)'로 호출하면,
+# 자동으로 DB 커넥션을 하나 꺼내주고, 요청이 끝나면 닫아줍니다.
 get_db = get_db_session
 
 def parse_keywords(keyword_str: str) -> List[str]:
-    """DB에 저장된 문자열 형태의 키워드를 리스트로 변환"""
+    """
+    [유틸리티 함수]
+    DB에 저장된 키워드 문자열은 "[('키워드', 10), ...]" 형태의 텍스트입니다.
+    이것을 파이썬 리스트 ['키워드', ...] 형태로 예쁘게 변환해줍니다.
+    
+    Args:
+        keyword_str (str): DB에서 꺼낸 raw string
+        
+    Returns:
+        List[str]: 파싱된 키워드 리스트 (실패 시 빈 리스트 반환)
+    """
     try:
         if not keyword_str: return []
-        data = ast.literal_eval(keyword_str)
+        # 문자열로 된 리스트 표현식을 실제 파이썬 객체로 안전하게 변환
+        data = ast.literal_eval(keyword_str) 
+        # 튜플 (키워드, 빈도수) 중 키워드만 추출
         return [k for k, v in data] if isinstance(data, list) else []
     except:
         return []

--- a/apps/backend/app/api/deps.py
+++ b/apps/backend/app/api/deps.py
@@ -1,0 +1,16 @@
+# DB 세션을 가져오는 공통 함수.
+import ast
+from typing import List
+from apps.dataflow.common.db_sa import get_db_session
+
+# Controller에서 'Depends(get_db)'로 사용
+get_db = get_db_session
+
+def parse_keywords(keyword_str: str) -> List[str]:
+    """DB에 저장된 문자열 형태의 키워드를 리스트로 변환"""
+    try:
+        if not keyword_str: return []
+        data = ast.literal_eval(keyword_str)
+        return [k for k, v in data] if isinstance(data, list) else []
+    except:
+        return []

--- a/apps/backend/app/api/endpoints/companies.py
+++ b/apps/backend/app/api/endpoints/companies.py
@@ -3,17 +3,24 @@ from typing import List
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
-from app.schemas.response_dto import CompanyItem
-from app.api.deps import get_db
-from apps.dataflow.common.models import Companies
+from app.schemas.response_dto import CompanyItem # 응답 모델
+from app.api.deps import get_db                  # DB 도구
+from apps.dataflow.common.models import Companies # DB 테이블
 
 router = APIRouter()
 
 @router.get("/companies", response_model=List[CompanyItem])
 async def search_companies(
-    query: str = Query(..., description="검색할 기업명"),
-    session: AsyncSession = Depends(get_db)
+    query: str = Query(..., description="검색할 기업명 (예: 삼성)"),
+    session: AsyncSession = Depends(get_db) # DB 세션 주입
 ):
+    """
+    기업명 검색 API (자동완성용)
+    입력받은 query가 포함된 기업 목록을 최대 10개 반환합니다.
+    """
+    # SQL: SELECT * FROM companies WHERE name_ko LIKE '%query%' LIMIT 10
     stmt = select(Companies).where(Companies.name_ko.like(f"%{query}%")).limit(10)
     result = await session.execute(stmt)
+    
+    # DB 모델(Companies)을 Pydantic 모델(CompanyItem)로 변환하여 반환
     return [CompanyItem(company_id=c.id, name_ko=c.name_ko) for c in result.scalars().all()]

--- a/apps/backend/app/api/endpoints/companies.py
+++ b/apps/backend/app/api/endpoints/companies.py
@@ -1,26 +1,46 @@
 from fastapi import APIRouter, Depends, Query
 from typing import List
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from google.cloud import bigquery
 
-from app.schemas.response_dto import CompanyItem # 응답 모델
-from app.api.deps import get_db                  # DB 도구
-from apps.dataflow.common.models import Companies # DB 테이블
+from app.schemas.response_dto import CompanyItem
+from app.api.deps import get_bq_client, PROJECT_ID, DATASET_ID
+from app.api.deps import get_bq_client, PROJECT_ID, DATASET_ID, RAW_TABLE_NAME
 
 router = APIRouter()
 
 @router.get("/companies", response_model=List[CompanyItem])
-async def search_companies(
+def search_companies(
     query: str = Query(..., description="검색할 기업명 (예: 삼성)"),
-    session: AsyncSession = Depends(get_db) # DB 세션 주입
+    client: bigquery.Client = Depends(get_bq_client)
 ):
     """
-    기업명 검색 API (자동완성용)
-    입력받은 query가 포함된 기업 목록을 최대 10개 반환합니다.
+    [기업 검색 API]
+    사용자가 입력한 검색어(query)가 포함된 회사 이름을 반환합니다.
+    회사 목록 테이블이 따로 없으므로, _raw 테이블의 'search_keyword'를 뒤져서 찾습니다.
     """
-    # SQL: SELECT * FROM companies WHERE name_ko LIKE '%query%' LIMIT 10
-    stmt = select(Companies).where(Companies.name_ko.like(f"%{query}%")).limit(10)
-    result = await session.execute(stmt)
+    #원본 데이터 테이블
+    table_id = f"{PROJECT_ID}.{DATASET_ID}.{RAW_TABLE_NAME}"
+
+    # search_keyword 컬럼을 name_ko별칭으로 가져옴
+    sql = f"""
+        SELECT DISTINCT search_keyword as name_ko
+        FROM `{table_id}`
+        WHERE search_keyword LIKE @query_pattern
+        LIMIT 10
+    """
     
-    # DB 모델(Companies)을 Pydantic 모델(CompanyItem)로 변환하여 반환
-    return [CompanyItem(company_id=c.id, name_ko=c.name_ko) for c in result.scalars().all()]
+    # SQL 파라미터 바인딩 (SQL Injection 방지)
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("query_pattern", "STRING", f"%{query}%")
+        ]
+    )
+
+    query_job = client.query(sql, job_config=job_config)
+    results = query_job.result()
+
+    #결과 반환 company_id는 임시로 해시값 사용
+    return [
+        CompanyItem(company_id=abs(hash(row.name_ko)) % 100000, name_ko=row.name_ko) 
+        for row in results if row.name_ko
+    ]

--- a/apps/backend/app/api/endpoints/companies.py
+++ b/apps/backend/app/api/endpoints/companies.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, Depends, Query
+from typing import List
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.schemas.response_dto import CompanyItem
+from app.api.deps import get_db
+from apps.dataflow.common.models import Companies
+
+router = APIRouter()
+
+@router.get("/companies", response_model=List[CompanyItem])
+async def search_companies(
+    query: str = Query(..., description="검색할 기업명"),
+    session: AsyncSession = Depends(get_db)
+):
+    stmt = select(Companies).where(Companies.name_ko.like(f"%{query}%")).limit(10)
+    result = await session.execute(stmt)
+    return [CompanyItem(company_id=c.id, name_ko=c.name_ko) for c in result.scalars().all()]

--- a/apps/backend/app/api/endpoints/news.py
+++ b/apps/backend/app/api/endpoints/news.py
@@ -1,37 +1,80 @@
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from google.cloud import bigquery
 from datetime import datetime
+from urllib.parse import urlparse
 
 from app.schemas.response_dto import NewsDetailResponse
-from app.api.deps import get_db
-from apps.dataflow.common.models import NewsArticle
+from app.api.deps import (
+    get_bq_client, PROJECT_ID, DATASET_ID, 
+    RAW_TABLE_NAME, LLM_TABLE_NAME # 추가됨
+)
 
 router = APIRouter()
 
-@router.get("/news/{article_id}", response_model=NewsDetailResponse)
-async def get_news_detail(
-    article_id: int,
-    session: AsyncSession = Depends(get_db)
-):
-    """
-    [뉴스 상세] 특정 뉴스 ID(article_id)의 상세 정보를 반환합니다.
-    """
-    # PK(Primary Key)로 기사 1건 조회
-    stmt = select(NewsArticle).where(NewsArticle.article_id == article_id)
-    article = (await session.execute(stmt)).scalars().first()
-    
-    if not article:
-        raise HTTPException(404, "해당 뉴스를 찾을 수 없습니다.")
 
-    # [임시 로직] AI 요약 컬럼이 없으므로, 본문 앞부분을 요약으로 사용
-    summary_text = article.content[:200] + "..." if article.content else "본문 내용 없음"
+
+@router.get("/news/{article_id}", response_model=NewsDetailResponse)
+def get_news_detail(
+    article_id: int,
+    client: bigquery.Client = Depends(get_bq_client)
+):  
+    """
+    뉴스 상세 조회 API : 기사 ID로 본문과 분석 결과(인사이트, 요약) 모두 조회.
+    """
+    raw_id = f"{PROJECT_ID}.{DATASET_ID}.{RAW_TABLE_NAME}"
+    llm_id = f"{PROJECT_ID}.{DATASET_ID}.{LLM_TABLE_NAME}"
+    
+    # [JOIN] 상세 정보 조회
+    sql = f"""
+        SELECT 
+            r.article_id, 
+            r.title, 
+            r.content, 
+            r.published_at, 
+            r.url,
+            l.summary,
+            l.career_insight
+        FROM `{raw_id}` as r
+        JOIN `{llm_id}` as l ON r.article_id = l.article_id
+        WHERE r.article_id = @article_id
+        LIMIT 1
+    """
+    
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("article_id", "INT64", article_id)
+        ]
+    )
+    
+    rows = list(client.query(sql, job_config=job_config).result())
+    
+    if not rows:
+        raise HTTPException(404, "해당 뉴스를 찾을 수 없습니다.")
+        
+    article = rows[0]
+    
+    #URL 파싱
+    source_name = "언론사"
+    if article.url:
+        try:
+            source_name = urlparse(article.url).netloc.replace("www.", "")
+        except:
+            pass
+    
+    # 요약 우선 순위 : 테이블 요약 -> 커리어 인사이트 -> 본문 앞부분
+    final_summary = "요약 없음"
+    if article.summary:
+        final_summary = article.summary
+    elif article.career_insight:
+        final_summary = f"[커리어 인사이트]\n{article.career_insight}"
+    elif article.content:
+        final_summary = article.content[:300] + "..."
 
     return NewsDetailResponse(
         article_id=article.article_id,
         title=article.title,
-        source="언론사",
-        published_at=article.published_at or datetime.now(),
-        key_summary=summary_text,
+        source=source_name,
+        published_at=article.published_at,
+        key_summary=final_summary,
         original_link=article.url
     )

--- a/apps/backend/app/api/endpoints/news.py
+++ b/apps/backend/app/api/endpoints/news.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from datetime import datetime
+
+from app.schemas.response_dto import NewsDetailResponse
+from app.api.deps import get_db
+from apps.dataflow.common.models import NewsArticle
+
+router = APIRouter()
+
+@router.get("/news/{article_id}", response_model=NewsDetailResponse)
+async def get_news_detail(article_id: int, session: AsyncSession = Depends(get_db)):
+    stmt = select(NewsArticle).where(NewsArticle.article_id == article_id)
+    article = (await session.execute(stmt)).scalars().first()
+    
+    if not article: raise HTTPException(404, "Article not found")
+
+    return NewsDetailResponse(
+        article_id=article.article_id,
+        title=article.title,
+        source="언론사",
+        published_at=article.published_at or datetime.now(),
+        key_summary=article.content[:200] if article.content else "",
+        original_link=article.url
+    )

--- a/apps/backend/app/api/endpoints/news.py
+++ b/apps/backend/app/api/endpoints/news.py
@@ -10,17 +10,28 @@ from apps.dataflow.common.models import NewsArticle
 router = APIRouter()
 
 @router.get("/news/{article_id}", response_model=NewsDetailResponse)
-async def get_news_detail(article_id: int, session: AsyncSession = Depends(get_db)):
+async def get_news_detail(
+    article_id: int,
+    session: AsyncSession = Depends(get_db)
+):
+    """
+    [뉴스 상세] 특정 뉴스 ID(article_id)의 상세 정보를 반환합니다.
+    """
+    # PK(Primary Key)로 기사 1건 조회
     stmt = select(NewsArticle).where(NewsArticle.article_id == article_id)
     article = (await session.execute(stmt)).scalars().first()
     
-    if not article: raise HTTPException(404, "Article not found")
+    if not article:
+        raise HTTPException(404, "해당 뉴스를 찾을 수 없습니다.")
+
+    # [임시 로직] AI 요약 컬럼이 없으므로, 본문 앞부분을 요약으로 사용
+    summary_text = article.content[:200] + "..." if article.content else "본문 내용 없음"
 
     return NewsDetailResponse(
         article_id=article.article_id,
         title=article.title,
         source="언론사",
         published_at=article.published_at or datetime.now(),
-        key_summary=article.content[:200] if article.content else "",
+        key_summary=summary_text,
         original_link=article.url
     )

--- a/apps/backend/app/api/endpoints/reports.py
+++ b/apps/backend/app/api/endpoints/reports.py
@@ -30,7 +30,7 @@ def get_report_summary(
         SELECT 
             r.article_id, 
             r.title, 
-            l.sentiment_score, 
+            l.sentiment, 
             l.one_sentence_summary
         FROM `{raw_id}` as r
         JOIN `{llm_id}` as l ON r.article_id = l.article_id
@@ -51,7 +51,7 @@ def get_report_summary(
     if not rows:
         raise HTTPException(404, "해당 기업의 분석 데이터를 찾을 수 없습니다.")
 
-    # [수정됨] 점수 계산 대신 글자('긍정', '부정')를 직접 셉니다.
+    # 점수 계산 대신 글자('긍정', '부정')를 직접 셉니다.
     total = len(rows)
     pos = 0
     neg = 0
@@ -116,8 +116,8 @@ def get_report_news_list(
     """
     뉴스 리스트 API : 필터링(긍/부정) 및 정렬 기능을 포함한 뉴스 목록 반환.
     """
-    raw_id = f"{PROJECT_ID}.{DATASET_ID}.{RAW_TABLE}"
-    llm_id = f"{PROJECT_ID}.{DATASET_ID}.{LLM_TABLE}"
+    raw_id = f"{PROJECT_ID}.{DATASET_ID}.{RAW_TABLE_NAME}"
+    llm_id = f"{PROJECT_ID}.{DATASET_ID}.{LLM_TABLE_NAME}"
     
     sql = f"""
         SELECT 
@@ -125,7 +125,7 @@ def get_report_news_list(
             r.title, 
             r.published_at, 
             r.url,
-            l.sentiment_score, 
+            l.sentiment, 
             l.topic, 
             l.one_sentence_summary
         FROM `{raw_id}` as r
@@ -175,7 +175,7 @@ def get_report_news_list(
             title=row.title,
             one_line_summary=row.one_sentence_summary if row.one_sentence_summary else row.title,
             source=source_name,  # 추출한 도메인 사용
-            published_at=row.published_at  # (None 허용은 response_dto 수정 후 문제 없음)
+            published_at=row.published_at if row.published_at else datetime.now() # (None 허용은 response_dto 수정 후 문제 없음)
         ))
     
     #딕셔너리를 리스트 형태로 반환

--- a/apps/backend/app/api/endpoints/reports.py
+++ b/apps/backend/app/api/endpoints/reports.py
@@ -1,111 +1,189 @@
-from fastapi import APIRouter, Depends, Query, HTTPException
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, desc
+from fastapi import APIRouter, Depends, HTTPException, Query
+from google.cloud import bigquery
+from typing import List, Optional
+from datetime import datetime
+from urllib.parse import urlparse
 
 from app.schemas import response_dto
-from app.api.deps import get_db, parse_keywords
-from apps.dataflow.common.models import Companies, NewsArticle
-from datetime import datetime
+
+from app.api.deps import (
+    get_bq_client, PROJECT_ID, DATASET_ID, 
+    RAW_TABLE_NAME, LLM_TABLE_NAME
+)
 
 router = APIRouter()
 
+
 @router.get("/report/summary", response_model=response_dto.ReportSummaryResponse)
-async def get_report_summary(
+def get_report_summary(
     company_name: str,
-    session: AsyncSession = Depends(get_db)
-):
+    client: bigquery.Client = Depends(get_bq_client)
+):  
     """
-    [리포트 상단] 기업의 뉴스 긍/부정 비율과 AI 요약을 반환합니다.
+    리포트 상단 요약 API : 특정 기업 뉴스 긍/부정 비율+주요 요약 포인트
     """
-    # 1. 기업명으로 ID 조회
-    stmt_co = select(Companies).where(Companies.name_ko == company_name)
-    company = (await session.execute(stmt_co)).scalars().first()
-    if not company: 
-        raise HTTPException(404, "해당 기업을 찾을 수 없습니다.")
-
-    # 2. 최근 뉴스 100개 조회
-    stmt_news = select(NewsArticle).where(NewsArticle.company_id == company.id).limit(100)
-    articles = (await session.execute(stmt_news)).scalars().all()
-
-    # 3. 긍/부정 비율 실시간 계산
-    total = len(articles)
-    ratio = {"positive": 0.0, "negative": 0.0, "neutral": 0.0}
+    raw_id = f"{PROJECT_ID}.{DATASET_ID}.{RAW_TABLE_NAME}"
+    llm_id = f"{PROJECT_ID}.{DATASET_ID}.{LLM_TABLE_NAME}"
     
-    if total > 0:
-        pos = sum(1 for a in articles if a.score > 0) # 긍정 점수 양수
-        neg = sum(1 for a in articles if a.score < 0) # 부정 점수 음수
+    # article_id기준으로 합쳐서 필요한 정보만 가져옴.
+    sql = f"""
+        SELECT 
+            r.article_id, 
+            r.title, 
+            l.sentiment_score, 
+            l.one_sentence_summary
+        FROM `{raw_id}` as r
+        JOIN `{llm_id}` as l ON r.article_id = l.article_id
+        WHERE r.search_keyword = @company_name
+        ORDER BY r.published_at DESC
+        LIMIT 100
+    """
+    
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("company_name", "STRING", company_name)
+        ]
+    )
+    
+    # 쿼리 실행 및 결과 리스트 반환
+    rows = list(client.query(sql, job_config=job_config).result())
+    
+    if not rows:
+        raise HTTPException(404, "해당 기업의 분석 데이터를 찾을 수 없습니다.")
+
+    # [수정됨] 점수 계산 대신 글자('긍정', '부정')를 직접 셉니다.
+    total = len(rows)
+    pos = 0
+    neg = 0
+    
+    for r in rows:
+        # 1. 값이 없으면 스킵
+        if not r.sentiment:
+            continue
+            
+        # 2. 소문자로 바꿔서 비교 (대소문자 무시)
+        s = r.sentiment.lower()
         
-        ratio = {
-            "positive": round(pos / total, 2),
-            "negative": round(neg / total, 2),
-            "neutral": round((total - pos - neg) / total, 2)
-        }
+        # 3. 'positive' 또는 '긍정'이 포함되어 있으면 카운트
+        if "positive" in s or "긍정" in s:
+            pos += 1
+        # 4. 'negative' 또는 '부정'이 포함되어 있으면 카운트
+        elif "negative" in s or "부정" in s:
+            neg += 1
+            
+    neu = total - (pos + neg)
+    
+    ratio = response_dto.SentimentRatio(
+        positive=round(pos/total, 2) if total else 0,
+        negative=round(neg/total, 2) if total else 0,
+        neutral=round(neu/total, 2) if total else 0
+    )
+
+    # 요약 포인트 
+    def is_positive(text):
+        if not text: return False
+        t = text.lower()
+        return "positive" in t or "긍정" in t
+
+    def is_negative(text):
+        if not text: return False
+        t = text.lower()
+        return "negative" in t or "부정" in t
+
+    pos_points = [r.one_sentence_summary or r.title for r in rows if is_positive(r.sentiment)][:3]
+    neg_points = [r.one_sentence_summary or r.title for r in rows if is_negative(r.sentiment)][:3]
+    
+    # 요약 없으면 제목으로 대체
+    if not pos_points:
+        pos_points = [r.title for r in rows if is_positive(r.sentiment)][:3]
+    if not neg_points:
+        neg_points = [r.title for r in rows if is_negative(r.sentiment)][:3]
 
     return response_dto.ReportSummaryResponse(
-        company_name=company.name_ko,
-        sentiment_ratio=response_dto.SentimentRatio(**ratio),
-        # [TODO] 실제 AI 요약 데이터 연동 전이므로 임시 메시지 반환
-        positive_points=["최근 긍정적인 기사가 다수 포착되었습니다.", "관련 기술 투자가 활발합니다."],
-        risk_factors=["글로벌 경기 변동성에 주의가 필요합니다."]
+        company_name=company_name,
+        sentiment_ratio=ratio,
+        positive_points=pos_points if pos_points else ["긍정적인 주요 이슈가 없습니다."],
+        risk_factors=neg_points if neg_points else ["부정적인 주요 리스크가 없습니다."]
     )
 
 @router.get("/report/news", response_model=response_dto.ReportNewsResponse)
-async def get_report_news(
+def get_report_news_list(
     company_name: str,
-    sentiment: str = Query(None, description="'positive' 또는 'negative'"),
-    sort_order: str = Query("latest", description="'latest'(최신순) 또는 'oldest'(오래된순)"),
-    session: AsyncSession = Depends(get_db)
-):
+    sentiment: Optional[str] = Query(None, description="'positive' 또는 'negative'"),
+    sort_order: str = "newest",
+    client: bigquery.Client = Depends(get_bq_client)
+):  
     """
-    [리포트 하단] 뉴스 기사를 키워드별로 그룹핑하여 반환합니다.
-    필터링(긍/부정) 및 정렬 기능을 제공합니다.
+    뉴스 리스트 API : 필터링(긍/부정) 및 정렬 기능을 포함한 뉴스 목록 반환.
     """
-    # 1. 기업 정보 조회
-    stmt_co = select(Companies).where(Companies.name_ko == company_name)
-    company = (await session.execute(stmt_co)).scalars().first()
-    if not company: return {"keyword_groups": []}
-
-    # 2. 기본 쿼리 생성
-    query = select(NewsArticle).where(NewsArticle.company_id == company.id)
-
-    # 3. 필터링 적용 (긍정/부정)
+    raw_id = f"{PROJECT_ID}.{DATASET_ID}.{RAW_TABLE}"
+    llm_id = f"{PROJECT_ID}.{DATASET_ID}.{LLM_TABLE}"
+    
+    sql = f"""
+        SELECT 
+            r.article_id, 
+            r.title, 
+            r.published_at, 
+            r.url,
+            l.sentiment_score, 
+            l.topic, 
+            l.one_sentence_summary
+        FROM `{raw_id}` as r
+        JOIN `{llm_id}` as l ON r.article_id = l.article_id
+        WHERE r.search_keyword = @company_name
+    """
+    
     if sentiment == "positive":
-        query = query.where(NewsArticle.score > 0)
+        sql += " AND (LOWER(l.sentiment) LIKE '%positive%' OR l.sentiment LIKE '%긍정%')"
     elif sentiment == "negative":
-        query = query.where(NewsArticle.score < 0)
-
-    # 4. 정렬 적용
-    if sort_order == "oldest":
-        query = query.order_by(NewsArticle.published_at.asc())
-    else:
-        query = query.order_by(NewsArticle.published_at.desc())
-
-    # 5. 데이터 실행 (최대 50개)
-    articles = (await session.execute(query.limit(50))).scalars().all()
-
-    # 6. [Python 로직] 키워드별 그룹핑
-    groups = {}
-    for art in articles:
-        # DB의 문자열 키워드를 리스트로 변환
-        keywords = parse_keywords(art.matched_keywords)
-        # 첫 번째 키워드를 대표 키워드로 사용 (없으면 '기타')
-        main_kwd = keywords[0] if keywords else "기타"
+        sql += " AND (LOWER(l.sentiment) LIKE '%negative%' OR l.sentiment LIKE '%부정%')"
         
+    if sort_order == "oldest":
+        sql += " ORDER BY r.published_at ASC NULLS LAST"
+    else:
+        sql += " ORDER BY r.published_at DESC NULLS LAST"
+        
+    sql += " LIMIT 50"
+
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("company_name", "STRING", company_name)
+        ]
+    )
+
+    rows = list(client.query(sql, job_config=job_config).result())
+
+    #[데이터 가공] 토픽별 그룹핑 및 URL 파싱
+    groups = {}
+    for row in rows:
+        main_kwd = row.topic if row.topic else "기타"
+        
+        # URL에서 도메인 추출 로직
+        source_name = "언론사"
+        if row.url:
+            try:
+                parsed = urlparse(row.url)
+                source_name = parsed.netloc.replace("www.", "") # www. 제거
+            except:
+                pass
+
         if main_kwd not in groups:
             groups[main_kwd] = []
             
         groups[main_kwd].append(response_dto.NewsSimpleItem(
-            article_id=art.article_id,
-            title=art.title,
-            one_line_summary=art.title, # [TODO] AI 요약 컬럼 생기면 교체
-            source="언론사",
-            published_at=art.published_at or datetime.now()
+            article_id=row.article_id,
+            title=row.title,
+            one_line_summary=row.one_sentence_summary if row.one_sentence_summary else row.title,
+            source=source_name,  # 추출한 도메인 사용
+            published_at=row.published_at  # (None 허용은 response_dto 수정 후 문제 없음)
         ))
-
-    # 7. 딕셔너리를 리스트 응답 모델로 변환
-    keyword_groups = [
-        response_dto.KeywordGroup(keyword=k, news_items=v) 
+    
+    #딕셔너리를 리스트 형태로 반환
+    result_groups = [
+        response_dto.KeywordGroup(keyword=k, news_items=v)
         for k, v in groups.items()
     ]
     
-    return response_dto.ReportNewsResponse(keyword_groups=keyword_groups)
+    return response_dto.ReportNewsResponse(
+        keyword_groups=result_groups
+    )

--- a/apps/backend/app/api/endpoints/reports.py
+++ b/apps/backend/app/api/endpoints/reports.py
@@ -10,22 +10,31 @@ from datetime import datetime
 router = APIRouter()
 
 @router.get("/report/summary", response_model=response_dto.ReportSummaryResponse)
-async def get_report_summary(company_name: str, session: AsyncSession = Depends(get_db)):
-    # 1. 회사 조회
+async def get_report_summary(
+    company_name: str,
+    session: AsyncSession = Depends(get_db)
+):
+    """
+    [리포트 상단] 기업의 뉴스 긍/부정 비율과 AI 요약을 반환합니다.
+    """
+    # 1. 기업명으로 ID 조회
     stmt_co = select(Companies).where(Companies.name_ko == company_name)
     company = (await session.execute(stmt_co)).scalars().first()
-    if not company: raise HTTPException(404, "Company not found")
+    if not company: 
+        raise HTTPException(404, "해당 기업을 찾을 수 없습니다.")
 
-    # 2. 뉴스 조회 (최근 100개)
+    # 2. 최근 뉴스 100개 조회
     stmt_news = select(NewsArticle).where(NewsArticle.company_id == company.id).limit(100)
     articles = (await session.execute(stmt_news)).scalars().all()
 
-    # 3. 비율 계산 (Service 로직이 여기 들어감, 복잡해지면 crud/ 폴더로 이동 추천)
+    # 3. 긍/부정 비율 실시간 계산
     total = len(articles)
     ratio = {"positive": 0.0, "negative": 0.0, "neutral": 0.0}
+    
     if total > 0:
-        pos = sum(1 for a in articles if a.score > 0)
-        neg = sum(1 for a in articles if a.score < 0)
+        pos = sum(1 for a in articles if a.score > 0) # 긍정 점수 양수
+        neg = sum(1 for a in articles if a.score < 0) # 부정 점수 음수
+        
         ratio = {
             "positive": round(pos / total, 2),
             "negative": round(neg / total, 2),
@@ -35,16 +44,68 @@ async def get_report_summary(company_name: str, session: AsyncSession = Depends(
     return response_dto.ReportSummaryResponse(
         company_name=company.name_ko,
         sentiment_ratio=response_dto.SentimentRatio(**ratio),
-        positive_points=["DB/AI 연동 전 임시 데이터"],
-        risk_factors=["DB/AI 연동 전 임시 데이터"]
+        # [TODO] 실제 AI 요약 데이터 연동 전이므로 임시 메시지 반환
+        positive_points=["최근 긍정적인 기사가 다수 포착되었습니다.", "관련 기술 투자가 활발합니다."],
+        risk_factors=["글로벌 경기 변동성에 주의가 필요합니다."]
     )
 
 @router.get("/report/news", response_model=response_dto.ReportNewsResponse)
 async def get_report_news(
     company_name: str,
-    sentiment: str = Query(None),
-    sort_order: str = Query("latest"),
+    sentiment: str = Query(None, description="'positive' 또는 'negative'"),
+    sort_order: str = Query("latest", description="'latest'(최신순) 또는 'oldest'(오래된순)"),
     session: AsyncSession = Depends(get_db)
 ):
-    # (생략: 이전 코드와 동일한 로직, 파일만 분리됨)
-    return response_dto.ReportNewsResponse(keyword_groups=[])
+    """
+    [리포트 하단] 뉴스 기사를 키워드별로 그룹핑하여 반환합니다.
+    필터링(긍/부정) 및 정렬 기능을 제공합니다.
+    """
+    # 1. 기업 정보 조회
+    stmt_co = select(Companies).where(Companies.name_ko == company_name)
+    company = (await session.execute(stmt_co)).scalars().first()
+    if not company: return {"keyword_groups": []}
+
+    # 2. 기본 쿼리 생성
+    query = select(NewsArticle).where(NewsArticle.company_id == company.id)
+
+    # 3. 필터링 적용 (긍정/부정)
+    if sentiment == "positive":
+        query = query.where(NewsArticle.score > 0)
+    elif sentiment == "negative":
+        query = query.where(NewsArticle.score < 0)
+
+    # 4. 정렬 적용
+    if sort_order == "oldest":
+        query = query.order_by(NewsArticle.published_at.asc())
+    else:
+        query = query.order_by(NewsArticle.published_at.desc())
+
+    # 5. 데이터 실행 (최대 50개)
+    articles = (await session.execute(query.limit(50))).scalars().all()
+
+    # 6. [Python 로직] 키워드별 그룹핑
+    groups = {}
+    for art in articles:
+        # DB의 문자열 키워드를 리스트로 변환
+        keywords = parse_keywords(art.matched_keywords)
+        # 첫 번째 키워드를 대표 키워드로 사용 (없으면 '기타')
+        main_kwd = keywords[0] if keywords else "기타"
+        
+        if main_kwd not in groups:
+            groups[main_kwd] = []
+            
+        groups[main_kwd].append(response_dto.NewsSimpleItem(
+            article_id=art.article_id,
+            title=art.title,
+            one_line_summary=art.title, # [TODO] AI 요약 컬럼 생기면 교체
+            source="언론사",
+            published_at=art.published_at or datetime.now()
+        ))
+
+    # 7. 딕셔너리를 리스트 응답 모델로 변환
+    keyword_groups = [
+        response_dto.KeywordGroup(keyword=k, news_items=v) 
+        for k, v in groups.items()
+    ]
+    
+    return response_dto.ReportNewsResponse(keyword_groups=keyword_groups)

--- a/apps/backend/app/api/endpoints/reports.py
+++ b/apps/backend/app/api/endpoints/reports.py
@@ -1,0 +1,50 @@
+from fastapi import APIRouter, Depends, Query, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, desc
+
+from app.schemas import response_dto
+from app.api.deps import get_db, parse_keywords
+from apps.dataflow.common.models import Companies, NewsArticle
+from datetime import datetime
+
+router = APIRouter()
+
+@router.get("/report/summary", response_model=response_dto.ReportSummaryResponse)
+async def get_report_summary(company_name: str, session: AsyncSession = Depends(get_db)):
+    # 1. 회사 조회
+    stmt_co = select(Companies).where(Companies.name_ko == company_name)
+    company = (await session.execute(stmt_co)).scalars().first()
+    if not company: raise HTTPException(404, "Company not found")
+
+    # 2. 뉴스 조회 (최근 100개)
+    stmt_news = select(NewsArticle).where(NewsArticle.company_id == company.id).limit(100)
+    articles = (await session.execute(stmt_news)).scalars().all()
+
+    # 3. 비율 계산 (Service 로직이 여기 들어감, 복잡해지면 crud/ 폴더로 이동 추천)
+    total = len(articles)
+    ratio = {"positive": 0.0, "negative": 0.0, "neutral": 0.0}
+    if total > 0:
+        pos = sum(1 for a in articles if a.score > 0)
+        neg = sum(1 for a in articles if a.score < 0)
+        ratio = {
+            "positive": round(pos / total, 2),
+            "negative": round(neg / total, 2),
+            "neutral": round((total - pos - neg) / total, 2)
+        }
+
+    return response_dto.ReportSummaryResponse(
+        company_name=company.name_ko,
+        sentiment_ratio=response_dto.SentimentRatio(**ratio),
+        positive_points=["DB/AI 연동 전 임시 데이터"],
+        risk_factors=["DB/AI 연동 전 임시 데이터"]
+    )
+
+@router.get("/report/news", response_model=response_dto.ReportNewsResponse)
+async def get_report_news(
+    company_name: str,
+    sentiment: str = Query(None),
+    sort_order: str = Query("latest"),
+    session: AsyncSession = Depends(get_db)
+):
+    # (생략: 이전 코드와 동일한 로직, 파일만 분리됨)
+    return response_dto.ReportNewsResponse(keyword_groups=[])

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -1,7 +1,19 @@
-from fastapi import FastAPI
+# apps/backend/app/main.py
+from dotenv import load_dotenv # [추가]
+import os
 
-app = FastAPI()
+# [중요] 다른 imports보다 먼저 .env를 로드해야 합니다.
+# 그래야 아래 api_router -> config.py 가 실행될 때 환경변수가 채워져 있습니다.
+load_dotenv()
+
+from fastapi import FastAPI
+from app.api.api_router import api_router # 이 줄이 실행될 때 config.py도 실행됨
+
+app = FastAPI(title="InsightBee API")
+
+# 모든 라우터 등록 (프리픽스 /api 추가)
+app.include_router(api_router, prefix="/api")
 
 @app.get("/")
 def read_root():
-    return {"message": "Hello, InsightBee World"}
+    return {"message": "InsightBee API Server Running (Modularized)"}

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -1,19 +1,22 @@
-# apps/backend/app/main.py
-from dotenv import load_dotenv # [추가]
+from dotenv import load_dotenv
 import os
 
-# [중요] 다른 imports보다 먼저 .env를 로드해야 합니다.
-# 그래야 아래 api_router -> config.py 가 실행될 때 환경변수가 채워져 있습니다.
+# 1. [필수] 앱 시작 전 환경변수(.env) 로드
+# DB 접속 정보 등을 config.py가 읽기 전에 메모리에 올려야 에러가 안 납니다.
 load_dotenv()
 
 from fastapi import FastAPI
-from app.api.api_router import api_router # 이 줄이 실행될 때 config.py도 실행됨
+from app.api.api_router import api_router
 
+# FastAPI 앱 인스턴스 생성
 app = FastAPI(title="InsightBee API")
 
-# 모든 라우터 등록 (프리픽스 /api 추가)
+# 2. 통합된 라우터 등록
+# 모든 API 주소 앞에 자동으로 '/api' 접두사가 붙습니다.
+# 예: /companies -> /api/companies
 app.include_router(api_router, prefix="/api")
 
 @app.get("/")
 def read_root():
+    """서버 상태 확인용 기본 루트 API"""
     return {"message": "InsightBee API Server Running (Modularized)"}

--- a/apps/backend/app/schemas/response_dto.py
+++ b/apps/backend/app/schemas/response_dto.py
@@ -1,44 +1,80 @@
-# apps/backend/app/schemas/response_dto.py
 from pydantic import BaseModel
 from typing import List, Optional
 from datetime import datetime
 
-# --- 공통 ---
+# ==========================================
+# [공통 사용 모델]
+# 여러 API에서 재사용되는 작은 부품들입니다.
+# ==========================================
+
 class SentimentRatio(BaseModel):
+    """
+    뉴스 기사들의 긍정/부정/중립 비율을 나타냅니다.
+    값은 0.0 ~ 1.0 사이의 실수(float)입니다.
+    """
     positive: float
     negative: float
     neutral: float
 
 class CompanyItem(BaseModel):
+    """
+    기업 검색 결과에 사용되는 기본 기업 정보 객체입니다.
+    """
     company_id: int
     name_ko: str
 
-# --- 리포트 ---
+# ==========================================
+# [API별 응답(Response) 모델]
+# 실제 API가 반환하는 최종 JSON 구조입니다.
+# ==========================================
+
+# --- 1. 리포트 페이지용 ---
+
 class ReportSummaryResponse(BaseModel):
+    """
+    [리포트 페이지 상단] 
+    기업 정보, 긍/부정 차트 데이터, AI 요약 포인트를 포함합니다.
+    """
     company_name: str
-    sentiment_ratio: SentimentRatio
-    positive_points: List[str]
-    risk_factors: List[str]
+    sentiment_ratio: SentimentRatio # 위에서 정의한 SentimentRatio 모델 재사용
+    positive_points: List[str]      # AI가 분석한 긍정적 요소 (문장 리스트)
+    risk_factors: List[str]         # AI가 분석한 리스크 요소 (문장 리스트)
 
 class NewsSimpleItem(BaseModel):
+    """
+    리스트에 표시될 뉴스 기사 요약 정보입니다.
+    """
     article_id: int
     title: str
-    one_line_summary: str
-    source: str
-    published_at: datetime
+    one_line_summary: str      # 기사 한 줄 요약 (현재는 제목 사용 중)
+    source: str                # 언론사 이름
+    published_at: datetime     # 발행일
 
 class KeywordGroup(BaseModel):
+    """
+    특정 키워드로 묶인 뉴스 기사 그룹입니다.
+    예: "AI" 키워드 그룹 -> [기사1, 기사2...]
+    """
     keyword: str
     news_items: List[NewsSimpleItem]
 
 class ReportNewsResponse(BaseModel):
+    """
+    [리포트 페이지 하단]
+    키워드별로 그룹핑된 뉴스 목록 전체를 반환합니다.
+    """
     keyword_groups: List[KeywordGroup]
 
-# --- 뉴스 상세 ---
+# --- 2. 뉴스 상세 페이지용 ---
+
 class NewsDetailResponse(BaseModel):
+    """
+    [뉴스 상세 페이지]
+    기사 클릭 시 보여줄 상세 정보를 정의합니다.
+    """
     article_id: int
     title: str
     source: str
     published_at: datetime
-    key_summary: str
-    original_link: str
+    key_summary: str           # 기사 핵심 내용 요약 (AI 또는 앞부분 발췌)
+    original_link: str         # '원문 보러가기' 링크

--- a/apps/backend/app/schemas/response_dto.py
+++ b/apps/backend/app/schemas/response_dto.py
@@ -4,13 +4,12 @@ from datetime import datetime
 
 # ==========================================
 # [공통 사용 모델]
-# 여러 API에서 재사용되는 작은 부품들입니다.
 # ==========================================
 
 class SentimentRatio(BaseModel):
     """
     뉴스 기사들의 긍정/부정/중립 비율을 나타냅니다.
-    값은 0.0 ~ 1.0 사이의 실수(float)입니다.
+    값은 0.0 ~ 1.0 사이의 실수(float)
     """
     positive: float
     negative: float
@@ -18,50 +17,46 @@ class SentimentRatio(BaseModel):
 
 class CompanyItem(BaseModel):
     """
-    기업 검색 결과에 사용되는 기본 기업 정보 객체입니다.
+    기업 검색 결과 항목
     """
     company_id: int
     name_ko: str
 
 # ==========================================
 # [API별 응답(Response) 모델]
-# 실제 API가 반환하는 최종 JSON 구조입니다.
 # ==========================================
 
 # --- 1. 리포트 페이지용 ---
 
 class ReportSummaryResponse(BaseModel):
     """
-    [리포트 페이지 상단] 
-    기업 정보, 긍/부정 차트 데이터, AI 요약 포인트를 포함합니다.
+    리포트 상단 : 요약 정보 및 통계
     """
     company_name: str
     sentiment_ratio: SentimentRatio # 위에서 정의한 SentimentRatio 모델 재사용
-    positive_points: List[str]      # AI가 분석한 긍정적 요소 (문장 리스트)
-    risk_factors: List[str]         # AI가 분석한 리스크 요소 (문장 리스트)
+    positive_points: List[str]      # 긍정 요약 문장
+    risk_factors: List[str]         # 부정 요약 문장
 
 class NewsSimpleItem(BaseModel):
     """
-    리스트에 표시될 뉴스 기사 요약 정보입니다.
+    뉴스 리스트 아이템
     """
     article_id: int
     title: str
-    one_line_summary: str      # 기사 한 줄 요약 (현재는 제목 사용 중)
+    one_line_summary: str      
     source: str                # 언론사 이름
-    published_at: datetime     # 발행일
+    published_at: Optional[datetime]     # 발행일(날짜 없을 경우 -> null)
 
 class KeywordGroup(BaseModel):
     """
     특정 키워드로 묶인 뉴스 기사 그룹입니다.
-    예: "AI" 키워드 그룹 -> [기사1, 기사2...]
     """
     keyword: str
     news_items: List[NewsSimpleItem]
 
 class ReportNewsResponse(BaseModel):
     """
-    [리포트 페이지 하단]
-    키워드별로 그룹핑된 뉴스 목록 전체를 반환합니다.
+    리포트 하단 : 뉴스 목록 전체
     """
     keyword_groups: List[KeywordGroup]
 
@@ -70,11 +65,10 @@ class ReportNewsResponse(BaseModel):
 class NewsDetailResponse(BaseModel):
     """
     [뉴스 상세 페이지]
-    기사 클릭 시 보여줄 상세 정보를 정의합니다.
     """
     article_id: int
     title: str
     source: str
-    published_at: datetime
-    key_summary: str           # 기사 핵심 내용 요약 (AI 또는 앞부분 발췌)
-    original_link: str         # '원문 보러가기' 링크
+    published_at: Optional[datetime]
+    key_summary: str           # 기사 핵심 내용 요약
+    original_link: str         # 원본 링크

--- a/apps/backend/app/schemas/response_dto.py
+++ b/apps/backend/app/schemas/response_dto.py
@@ -1,0 +1,44 @@
+# apps/backend/app/schemas/response_dto.py
+from pydantic import BaseModel
+from typing import List, Optional
+from datetime import datetime
+
+# --- 공통 ---
+class SentimentRatio(BaseModel):
+    positive: float
+    negative: float
+    neutral: float
+
+class CompanyItem(BaseModel):
+    company_id: int
+    name_ko: str
+
+# --- 리포트 ---
+class ReportSummaryResponse(BaseModel):
+    company_name: str
+    sentiment_ratio: SentimentRatio
+    positive_points: List[str]
+    risk_factors: List[str]
+
+class NewsSimpleItem(BaseModel):
+    article_id: int
+    title: str
+    one_line_summary: str
+    source: str
+    published_at: datetime
+
+class KeywordGroup(BaseModel):
+    keyword: str
+    news_items: List[NewsSimpleItem]
+
+class ReportNewsResponse(BaseModel):
+    keyword_groups: List[KeywordGroup]
+
+# --- 뉴스 상세 ---
+class NewsDetailResponse(BaseModel):
+    article_id: int
+    title: str
+    source: str
+    published_at: datetime
+    key_summary: str
+    original_link: str


### PR DESCRIPTION
`## 📋 개요
백엔드 API 서버의 **전체적인 아키텍처를 설계하고 핵심 기능(기업 검색, 리포트 분석, 뉴스 상세)을 구현**했습니다.
기존 RDB(Cloud SQL) 연결 방식을 **데이터 분석에 최적화된 BigQuery 직접 연동 방식**으로 변경하였으며,
크롤링 원본 데이터(`raw`)와 LLM 분석 데이터(`llm`)를 결합하여 인사이트를 제공하는 로직을 완성했습니다.

## 🛠 주요 변경 사항
 ㅇ
### 1. 아키텍처 및 설정
- **BigQuery 연동:** `sqlalchemy` 대신 `google-cloud-bigquery`를 사용하여 대용량 데이터 조회 속도를 확보했습니다.
- **의존성 주입(Dependency Injection):** `deps.py`를 통해 BigQuery Client를 효율적으로 생성하고 관리(Yield)하도록 구조화했습니다.

### 2. API 엔드포인트 구현 (`/api`)
| 기능 | Method | 경로 | 설명 |
|---|---|---|---|
| **기업 검색** | `GET` | `/companies` | 뉴스 데이터(`search_keyword`) 기반 기업 자동완성 검색 |
| **리포트 요약** | `GET` | `/report/summary` | 기업의 뉴스 긍/부정 비율 통계 및 핵심 요약 포인트 제공 |
| **뉴스 리스트** | `GET` | `/report/news` | 필터링(긍/부정), 정렬, 출처 파싱이 적용된 뉴스 목록 제공 |
| **뉴스 상세** | `GET` | `/news/{id}` | 뉴스 본문과 LLM 인사이트/요약 정보를 결합하여 제공 |

### 3. 핵심 비즈니스 로직
- **Table JOIN:** `news_articles_raw`(제목, 날짜, URL)와 `news_articles_llm`(점수, 요약, 토픽) 테이블을 `article_id` 기준으로 조인하여 데이터를 통합했습니다.
- **데이터 가공:**
  - **URL 파싱:** 긴 뉴스 URL에서 도메인(예: `n.news.naver.com`)만 추출하여 가독성을 높였습니다.
  - **NULL 처리:** 날짜(`published_at`)가 없는 데이터는 정렬 시 맨 뒤로 보내도록(`NULLS LAST`) 처리했습니다.

## 🧱 프로젝트 구조 (Files)
```text
apps/backend/app/
├── main.py                # 앱 진입점 (CORS 설정, 라우터 등록)
├── api/
│   ├── deps.py            # BigQuery 연결 및 환경변수 로드
│   ├── api_router.py      # API 라우터 통합
│   └── endpoints/         # 핵심 로직 (Controller)
│       ├── companies.py
│       ├── reports.py
│       └── news.py
└── schemas/
    └── response_dto.py    # 데이터 검증 및 응답 모델 (Pydantic)`
    
## 실행방법
uvicorn app.main:app --reload
Swagger UI (API 문서): http://127.0.0.1:8000/docs

## 라이브러리
fastapi
uvicorn[standard]
google-cloud-bigquery
python-dotenv
pydantic